### PR TITLE
Fix time to expiration calculation for future dates

### DIFF
--- a/src/components/generated/StrikePriceConfigSection.tsx
+++ b/src/components/generated/StrikePriceConfigSection.tsx
@@ -25,9 +25,17 @@ const StrikePriceConfigSection: React.FC<StrikePriceConfigSectionProps> = ({
   // Calculate time to expiration based on selected date
   // For 0DTE strategies, the expiration is the same as the trading date
   const expirationDate = getExpirationDate('0dte', selectedDate);
-  // Calculate time from now to the selected date (for display purposes)
-  const displayTimeToExpiration = calculateTimeToExpiration(selectedDate || new Date());
-  // For delta calculations, use 0DTE (very small time value)
+  
+  // Calculate actual days between today and selected date for display
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tradingDate = selectedDate || new Date();
+  const tradingDateNormalized = new Date(tradingDate);
+  tradingDateNormalized.setHours(0, 0, 0, 0);
+  const daysDiff = Math.round((tradingDateNormalized.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  const displayTimeToExpiration = Math.max(0, daysDiff) / 365.25; // Convert days to years for display
+  
+  // For delta calculations, use 0DTE (very small time value) when trading date is selected
   const timeToExpiration = selectedDate ? 0.001 : displayTimeToExpiration;
   
   // Function to calculate delta for a given strike


### PR DESCRIPTION
## Summary
- Fixes Issue #19 where selecting future dates showed 0 days instead of the correct day count
- Now correctly calculates and displays the actual number of days between today and the selected trading date

## Problem
When selecting tomorrow (08/12/2025), the Time to Exp displayed "0 days" instead of "1 days". This was because the calculation was treating all dates as 0DTE.

## Solution
- Calculate actual days between today and selected trading date
- Normalize both dates to midnight for accurate day counting
- Convert days to years for display (matching the existing format)
- Keep delta calculations using small time value (0.001) for 0DTE strategies

## Testing
- Selecting today shows 0 days ✓
- Selecting tomorrow shows 1 day ✓
- Selecting future dates shows correct day count ✓
- Delta calculations still work correctly for 0DTE ✓

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)